### PR TITLE
coff-go32-exe: support variable length stub

### DIFF
--- a/bfd/coff-stgo32.c
+++ b/bfd/coff-stgo32.c
@@ -443,12 +443,15 @@ go32_stubbed_coff_bfd_copy_private_bfd_data (bfd *ibfd, bfd *obfd)
      optionally allocate the output stub.  */
   if (coff_data (obfd)->go32stub == NULL)
     coff_data (obfd)->go32stub = bfd_alloc (obfd,
-					  (bfd_size_type) bfd_coff_filhsz(ibfd) - 20);
+				 (bfd_size_type) bfd_coff_filhsz (ibfd) - 20);
 
   /* Now copy the stub.  */
   if (coff_data (obfd)->go32stub != NULL)
-    memcpy (coff_data (obfd)->go32stub, coff_data (ibfd)->go32stub,
-	    bfd_coff_filhsz(ibfd) - 20);
+    {
+      memcpy (coff_data (obfd)->go32stub, coff_data (ibfd)->go32stub,
+              bfd_coff_filhsz (ibfd) - 20);
+      bfd_coff_filhsz (obfd) = bfd_coff_filhsz (ibfd);
+    }
 
   return TRUE;
 }

--- a/bfd/coff-stgo32.c
+++ b/bfd/coff-stgo32.c
@@ -164,9 +164,9 @@ adjust_filehdr_in_pre  (bfd *  abfd,
   memcpy(filehdr_src->f_nscns,  p + 2,  2);
   memcpy(filehdr_src->f_magic,  p + 0,  2);
 
-  bfd_coff_filhsz(abfd) = stubsize + 20;
+  bfd_coff_filhsz (abfd) = stubsize + 20;
 
-  bfd_seek (abfd, bfd_coff_filhsz(abfd), SEEK_SET);
+  bfd_seek (abfd, bfd_coff_filhsz (abfd), SEEK_SET);
 }
 
 static void
@@ -198,11 +198,11 @@ adjust_filehdr_out_pre  (bfd * abfd, void * in, void * out)
 
   /* Copy the stub to the file header.  */
   if (coff_data (abfd)->go32stub != NULL)
-    memcpy (filehdr_out->hdr_data, coff_data(abfd)->go32stub, GO32_STUBSIZE);
+    memcpy (filehdr_out->hdr_data, coff_data (abfd)->go32stub, GO32_STUBSIZE);
   else
     {
       /* Use the default.  */
-      bfd_coff_filhsz(abfd) = GO32_STUBSIZE_DEFAULT;
+      bfd_coff_filhsz (abfd) = GO32_STUBSIZE_DEFAULT;
       memcpy (filehdr_out->hdr_data, stub_bytes, GO32_STUBSIZE);
     }
 

--- a/bfd/coff-stgo32.c
+++ b/bfd/coff-stgo32.c
@@ -409,8 +409,10 @@ create_go32_stub (bfd *abfd)
 	  bfd_release (abfd, coff_data (abfd)->go32stub);
 	  coff_data (abfd)->go32stub = NULL;
 	}
+      else
+        bfd_coff_filhsz (abfd) = coff_start + 20;
+
       close (f);
-      bfd_coff_filhsz(abfd) = coff_start;
     }
 stub_end:
   /* There was something wrong above, so use now the standard builtin

--- a/bfd/coff-stgo32.c
+++ b/bfd/coff-stgo32.c
@@ -189,7 +189,6 @@ adjust_filehdr_in_post  (bfd * abfd, void * src, void * dst)
   filehdr_dst->go32stub = bfd_malloc ((bfd_size_type) GO32_STUBSIZE);
   if (filehdr_dst->go32stub != NULL)
     memcpy (filehdr_dst->go32stub, filehdr_src->hdr_data, GO32_STUBSIZE);
-  filehdr_dst->f_flags |= F_GO32STUB;
 }
 
 static void

--- a/bfd/coff-stgo32.c
+++ b/bfd/coff-stgo32.c
@@ -206,7 +206,7 @@ adjust_filehdr_out_pre  (bfd * abfd, void * in, void * out)
   else
     {
       /* Use the default.  */
-      bfd_coff_filhsz (abfd) = GO32_STUBSIZE_DEFAULT;
+      bfd_coff_filhsz (abfd) = GO32_STUBSIZE_DEFAULT + 20;
       memcpy (filehdr_out->hdr_data, stub_bytes, GO32_STUBSIZE);
     }
 

--- a/bfd/coff-stgo32.c
+++ b/bfd/coff-stgo32.c
@@ -186,8 +186,9 @@ adjust_filehdr_in_post  (bfd * abfd, void * src, void * dst)
   /* Save now the stub to be used later.  Put the stub data to FILEHDR_DST
      first as coff_data (abfd) still does not exist.  It may not even be ever
      created as we are just checking the file format of ABFD.  */
-  filehdr_dst->go32stub = bfd_alloc (abfd, (bfd_size_type) GO32_STUBSIZE); /* TODO: check for null, TODO: free */
-  memcpy (filehdr_dst->go32stub, filehdr_src->hdr_data, GO32_STUBSIZE);
+  filehdr_dst->go32stub = bfd_malloc ((bfd_size_type) GO32_STUBSIZE);
+  if (filehdr_dst->go32stub != NULL)
+    memcpy (filehdr_dst->go32stub, filehdr_src->hdr_data, GO32_STUBSIZE);
   filehdr_dst->f_flags |= F_GO32STUB;
 }
 

--- a/bfd/coff-stgo32.c
+++ b/bfd/coff-stgo32.c
@@ -165,6 +165,8 @@ adjust_filehdr_in_pre  (bfd *  abfd,
   memcpy(filehdr_src->f_magic,  p + 0,  2);
 
   bfd_coff_filhsz(abfd) = stubsize + 20;
+
+  bfd_seek (abfd, bfd_coff_filhsz(abfd), SEEK_SET);
 }
 
 static void

--- a/bfd/coffcode.h
+++ b/bfd/coffcode.h
@@ -2114,10 +2114,13 @@ coff_mkobject_hook (bfd * abfd,
     {
       coff->go32stub = (char *) bfd_alloc (abfd, bfd_coff_filhsz(abfd) - 20);
       if (coff->go32stub == NULL)
-	return NULL;
+        coff = NULL;
     }
-  if (coff->go32stub != NULL)
+  if (coff != NULL && coff->go32stub != NULL)
     memcpy (coff->go32stub, internal_f->go32stub, bfd_coff_filhsz(abfd) - 20);
+
+  if (internal_f->go32stub != NULL)
+    free(internal_f->go32stub);
 
   return coff;
 }

--- a/bfd/coffcode.h
+++ b/bfd/coffcode.h
@@ -2110,17 +2110,15 @@ coff_mkobject_hook (bfd * abfd,
     abfd->flags |= HAS_DEBUG;
 #endif
 
-  if ((internal_f->f_flags & F_GO32STUB) != 0)
+  if (internal_f->go32stub != NULL)
     {
       coff->go32stub = (char *) bfd_alloc (abfd, bfd_coff_filhsz(abfd) - 20);
-      if (coff->go32stub == NULL)
+      if (coff->go32stub != NULL)
+        memcpy (coff->go32stub, internal_f->go32stub, bfd_coff_filhsz(abfd) - 20);
+      else
         coff = NULL;
+      free(internal_f->go32stub);
     }
-  if (coff != NULL && coff->go32stub != NULL)
-    memcpy (coff->go32stub, internal_f->go32stub, bfd_coff_filhsz(abfd) - 20);
-
-  if (internal_f->go32stub != NULL)
-    free(internal_f->go32stub);
 
   return coff;
 }

--- a/bfd/coffcode.h
+++ b/bfd/coffcode.h
@@ -2112,12 +2112,12 @@ coff_mkobject_hook (bfd * abfd,
 
   if ((internal_f->f_flags & F_GO32STUB) != 0)
     {
-      coff->go32stub = (char *) bfd_alloc (abfd, bfd_coff_filhsz(abfd));
+      coff->go32stub = (char *) bfd_alloc (abfd, bfd_coff_filhsz(abfd) - 20);
       if (coff->go32stub == NULL)
 	return NULL;
     }
   if (coff->go32stub != NULL)
-    memcpy (coff->go32stub, internal_f->go32stub, bfd_coff_filhsz(abfd));
+    memcpy (coff->go32stub, internal_f->go32stub, bfd_coff_filhsz(abfd) - 20);
 
   return coff;
 }

--- a/bfd/coffcode.h
+++ b/bfd/coffcode.h
@@ -4135,7 +4135,7 @@ coff_write_object_contents (bfd * abfd)
     char * buff;
     bfd_size_type amount = bfd_coff_filhsz (abfd);
 
-    buff = (char *) bfd_malloc (amount);
+    buff = (char *) bfd_malloc (sizeof (FILHDR));
     if (buff == NULL)
       return FALSE;
 

--- a/bfd/coffcode.h
+++ b/bfd/coffcode.h
@@ -2112,12 +2112,12 @@ coff_mkobject_hook (bfd * abfd,
 
   if ((internal_f->f_flags & F_GO32STUB) != 0)
     {
-      coff->go32stub = (char *) bfd_alloc (abfd, (bfd_size_type) GO32_STUBSIZE);
+      coff->go32stub = (char *) bfd_alloc (abfd, bfd_coff_filhsz(abfd));
       if (coff->go32stub == NULL)
 	return NULL;
     }
   if (coff->go32stub != NULL)
-    memcpy (coff->go32stub, internal_f->go32stub, GO32_STUBSIZE);
+    memcpy (coff->go32stub, internal_f->go32stub, bfd_coff_filhsz(abfd));
 
   return coff;
 }

--- a/bfd/coffcode.h
+++ b/bfd/coffcode.h
@@ -2046,7 +2046,11 @@ coff_mkobject_hook (bfd * abfd,
   coff_data_type *coff;
 
   if (! coff_mkobject (abfd))
-    return NULL;
+    {
+      if (internal_f->go32stub != NULL)
+          free (internal_f->go32stub);
+      return NULL;
+    }
 
   coff = coff_data (abfd);
 
@@ -2117,7 +2121,7 @@ coff_mkobject_hook (bfd * abfd,
         memcpy (coff->go32stub, internal_f->go32stub, bfd_coff_filhsz(abfd) - 20);
       else
         coff = NULL;
-      free(internal_f->go32stub);
+      free (internal_f->go32stub);
     }
 
   return coff;

--- a/bfd/coffcode.h
+++ b/bfd/coffcode.h
@@ -4135,7 +4135,7 @@ coff_write_object_contents (bfd * abfd)
     char * buff;
     bfd_size_type amount = bfd_coff_filhsz (abfd);
 
-    buff = (char *) bfd_malloc (sizeof (FILHDR));
+    buff = (char *) bfd_malloc (FILHSZ);
     if (buff == NULL)
       return FALSE;
 

--- a/include/coff/go32exe.h
+++ b/include/coff/go32exe.h
@@ -17,10 +17,16 @@
    Foundation, Inc., 51 Franklin Street - Fifth Floor, Boston,
    MA 02110-1301, USA.  */
 
+#define GO32_MAX_STUBSIZE 8192
+
 struct external_filehdr_go32_exe
   {
-    char stub[GO32_STUBSIZE]; /* the stub to load the image */
-			/* the standard COFF header     */
+    char hdr_data[GO32_MAX_STUBSIZE + 20];  /* first 8k including stub
+                                               and COFF header */
+
+                        /* the standard COFF header     */
+                        /* the offset of these fields does not
+                           correspond with their offset in the file */
     char f_magic[2];	/* magic number			*/
     char f_nscns[2];	/* number of sections		*/
     char f_timdat[4];	/* time & date stamp		*/
@@ -33,4 +39,4 @@ struct external_filehdr_go32_exe
 #undef FILHDR
 #define	FILHDR	struct external_filehdr_go32_exe
 #undef FILHSZ
-#define	FILHSZ	GO32_STUBSIZE+20
+#define	FILHSZ	sizeof(FILHDR)

--- a/include/coff/go32exe.h
+++ b/include/coff/go32exe.h
@@ -39,4 +39,4 @@ struct external_filehdr_go32_exe
 #undef FILHDR
 #define	FILHDR	struct external_filehdr_go32_exe
 #undef FILHSZ
-#define	FILHSZ	sizeof(FILHDR)
+#define	FILHSZ	(GO32_MAX_STUBSIZE + 20 + 20)

--- a/include/coff/go32exe.h
+++ b/include/coff/go32exe.h
@@ -17,11 +17,13 @@
    Foundation, Inc., 51 Franklin Street - Fifth Floor, Boston,
    MA 02110-1301, USA.  */
 
-#define GO32_MAX_STUBSIZE 8192
+/* If ever necessary, this value can be increased with no ill effects,
+   provided that it stays below the smallest practical EXE size. */
+#define GO32STUB_SIZE_MAX 8192
 
 struct external_filehdr_go32_exe
   {
-    char hdr_data[GO32_MAX_STUBSIZE + 20];  /* first 8k including stub
+    char hdr_data[GO32STUB_SIZE_MAX + 20];  /* first 8k including stub
                                                and COFF header */
 
                         /* the standard COFF header     */
@@ -39,4 +41,4 @@ struct external_filehdr_go32_exe
 #undef FILHDR
 #define	FILHDR	struct external_filehdr_go32_exe
 #undef FILHSZ
-#define	FILHSZ	(GO32_MAX_STUBSIZE + 20 + 20)
+#define	FILHSZ	(GO32STUB_SIZE_MAX + 20 + 20)

--- a/include/coff/internal.h
+++ b/include/coff/internal.h
@@ -58,8 +58,6 @@ struct internal_extra_pe_filehdr
   bfd_vma  nt_signature;   	/* required NT signature, 0x4550 */
 };
 
-#define GO32_STUBSIZE 2048
-
 struct internal_filehdr
 {
   struct internal_extra_pe_filehdr pe;
@@ -69,7 +67,7 @@ struct internal_filehdr
 
      F_GO32STUB is set iff go32stub contains a valid data.  Artifical headers
      created in BFD have no pre-set go32stub.  */
-  char go32stub[GO32_STUBSIZE];
+  char* go32stub;
 
   /* Standard coff internal info.  */
   unsigned short f_magic;	/* magic number			*/

--- a/include/coff/internal.h
+++ b/include/coff/internal.h
@@ -91,8 +91,7 @@ struct internal_filehdr
  	F_AR32W		file is 32-bit big-endian
  	F_DYNLOAD	rs/6000 aix: dynamically loadable w/imports & exports
  	F_SHROBJ	rs/6000 aix: file is a shared object
-	F_DLL           PE format DLL
-	F_GO32STUB      Field go32stub contains valid data.  */
+	F_DLL           PE format DLL  */
 
 #define	F_RELFLG	(0x0001)
 #define	F_EXEC		(0x0002)
@@ -104,7 +103,6 @@ struct internal_filehdr
 #define	F_DYNLOAD	(0x1000)
 #define	F_SHROBJ	(0x2000)
 #define F_DLL           (0x2000)
-#define F_GO32STUB      (0x4000)
 
 /* Extra structure which is used in the optional header.  */
 typedef struct _IMAGE_DATA_DIRECTORY


### PR DESCRIPTION
continuation of jwt27/djgpp-cvs#3